### PR TITLE
Cleanup some warnings/failures on building with mkosi v25.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debian-tools/
 tmp/
 tools/
 containers/
+mkosi/

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ mkosi.key
 mkosi.crt
 debian-tools/
 tmp/
-
+tools/
 containers/

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ register:
 
 os_template: build convert upload upload_permissions register
 
-init:
+prereq:
+	@if [ ! -f $$HOME/.local/bin/mkosi ]; then echo ; echo "Use 'pipx install git+https://github.com/systemd/mkosi.git@v25.3' to install it."; exit 1; fi
+
+init: prereq
 	mkosi genkey
 
 # These rules do not correspond to a specific file

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ mkosi-install:
 	  git clone --depth 1 --branch 'v25.3' https://github.com/systemd/mkosi
 
 prereq: mkosi-install
-	sudo apt install debian-archive-keyring
+	sudo apt install debian-archive-keyring qemu-utils
 
 init: prereq
 	$(MKOSI) genkey

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ZONE:=at-vie-1
 ORG:=re-cinq
+SHA1   := $(shell git rev-parse --short HEAD)
 
 SHELL=/bin/env bash
 
@@ -10,10 +11,11 @@ boot:
 	mkosi --tools-tree=default --force boot
 
 convert:
-	qemu-img convert -f raw -O qcow2 image.raw image.qcow2
+	qemu-img convert -f raw -O qcow2 image.raw exoscale-lab-ai-$(SHA1).qcow2
+	ln -s exoscale-lab-ai-$(SHA1).qcow2 image.qcow2
 
 clean:
-	mkosi clean && rm image.qcow2
+	mkosi clean && rm *.qcow2
 
 hash:
 	md5sum image.qcow2

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ convert:
 	ln -s exoscale-lab-ai-$(SHA1).qcow2 image.qcow2
 
 clean:
-	$(MKOSI) clean
-	-rm *.qcow2
+	sudo rm -f *.deb
+	sudo $(MKOSI) clean
+	rm -f *.qcow2
 
 hash:
 	md5sum image.qcow2
@@ -38,11 +39,11 @@ register:
 os_template: build convert upload upload_permissions register
 
 mkosi-install:
-	[ ! -d mkosi ] || \
+	[ ! -d mkosi ] && \
 	  git clone --depth 1 --branch 'v25.3' https://github.com/systemd/mkosi
 
 prereq: mkosi-install
-	apt install debian-archive-keyring
+	sudo apt install debian-archive-keyring
 
 init: prereq
 	$(MKOSI) genkey

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -38,8 +38,8 @@ Bootable=true
 Ssh=yes
 Packages=
         linux-perf
-        linux-image-6.1.0-35-cloud-amd64
-        linux-headers-6.1.0-35-cloud-amd64
+        linux-image-cloud-amd64
+        linux-headers-cloud-amd64
         dkms
         systemd
         systemd-boot
@@ -73,5 +73,3 @@ Packages=
 
 [Validation]
 Checksum=true
-# root password
-#Password=mementomori

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -2,7 +2,6 @@
 
 [Distribution]
 Distribution=debian
-# 20.04 = focal
 Release=bookworm
 Repositories=contrib,non-free,non-free-firmware
 
@@ -11,13 +10,16 @@ Repositories=contrib,non-free,non-free-firmware
 Format=disk
 #Hostname=ai
 
-[Host]
+[Runtime]
 RuntimeSize=10G
-SshKey=/root/.ssh/id_ed25519.pub
 
 [Packages]
+# let mkosi.postinst access the internet
+# (needed because we are updating and installing packages there)
 WithNetwork=true
 BuildPackages=wget curl apt 
+# The packages to appear in the final image
+Packages=nano less tmux ssh dnsutils curl
 
 [Partitions]
 RootSize=5G
@@ -28,7 +30,6 @@ ToolsTreeCertificates=yes
 WithNetwork=true
 
 [Content]
-#RootPassword=recinqrocks
 Hostname=ai
 Locale=C.UTF-8
 Timezone=UTC
@@ -37,8 +38,8 @@ Bootable=true
 Ssh=yes
 Packages=
         linux-perf
-        linux-image-6.1.0-28-cloud-amd64
-        linux-headers-6.1.0-28-cloud-amd64
+        linux-image-6.1.0-35-cloud-amd64
+        linux-headers-6.1.0-35-cloud-amd64
         dkms
         systemd
         systemd-boot
@@ -69,15 +70,6 @@ Packages=
         ca-certificates
         curl
         sudo
-
-[Packages]
-# The packages to appear in the final image
-Packages=nano less tmux ssh dnsutils curl
-
-# let mkosi.postinst access the internet
-# (needed because we are updating and installing packages there)
-WithNetwork=true
-
 
 [Validation]
 Checksum=true

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -38,8 +38,8 @@ Bootable=true
 Ssh=yes
 Packages=
         linux-perf
-        linux-image-cloud-amd64
-        linux-headers-cloud-amd64
+        linux-image-amd64
+        linux-headers-amd64
         dkms
         systemd
         systemd-boot

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -67,6 +67,7 @@ apt install -y cuda-drivers
 # ---------------------------- install CUDA --------------------------
 echo -e "\n\nInstalling Nvidia CUDA...\n"
 
+rm -f cuda-repo-debian12-12-6-local_12.6.3-560.35.05-1_amd64.deb
 wget https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda-repo-debian12-12-6-local_12.6.3-560.35.05-1_amd64.deb
 
 dpkg -i cuda-repo-debian12-12-6-local_12.6.3-560.35.05-1_amd64.deb

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e 
+
 # From http://0pointer.net/blog/mkosi-a-tool-for-generating-os-images.html:
 # mkosi.postinst — If this executable script exists, it is invoked inside the
 # image (inside a systemd-nspawn invocation) and can adjust the image as it

--- a/mkosi.prepare
+++ b/mkosi.prepare
@@ -1,9 +1,0 @@
-#!/bin/bash
-# SPDX-License-Identifier: LGPL-2.1-or-later
-set -e
-
-if [ "$1" = "build" ]; then
-    exit 0
-fi
-
-mkosi-chroot "$SRCDIR"/bin/mkosi dependencies | xargs -d '\n' mkosi-install


### PR DESCRIPTION
These are some changes I needed to make to more easily get the template to build with mkosi v25.3.

The access to the root key is apparently not necessary, so I removed it.